### PR TITLE
アイテムに対する`sizedBox`の削除

### DIFF
--- a/lib/ui/features/ranking/ranking_page.dart
+++ b/lib/ui/features/ranking/ranking_page.dart
@@ -37,198 +37,189 @@ class _RankingScreenState extends State<RankingPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   // アイテムのセル
-                  SizedBox(
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
                     height: 210,
                     width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                            const Align(
-                                alignment: Alignment.topLeft,
-                                child: Icon(Icons.trending_up, size: 24)),
-                          ]),
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
+                              height: 90),
                           const Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                'SUQQU',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis,
-                              )),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('シグニチャー カラー アイズ',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥7,700', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.62', style: TextStyle(fontSize: 9)),
-                                Text('(8726件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                            const Align(
-                                alignment: Alignment.topLeft,
-                                child: Icon(Icons.trending_up, size: 24)),
-                          ]),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('Dior',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis),
-                          ),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('ディオールショウ サンク クルール',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥9,570', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.51', style: TextStyle(fontSize: 9)),
-                                Text('(913件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                            const Align(
-                                alignment: Alignment.topLeft,
-                                child: Icon(Icons.trending_up, size: 24)),
-                          ]),
-                          const Align(
+                              alignment: Alignment.topLeft,
+                              child: Icon(Icons.trending_up, size: 24)),
+                        ]),
+                        const Align(
                             alignment: Alignment.centerLeft,
                             child: Text(
-                              'TOM FORD BEAUTY(トムフォードビューティ)',
+                              'SUQQU',
                               style: TextStyle(
                                   fontSize: 11,
                                   fontWeight: FontWeight.bold,
                                   color: Color(0xFF777777)),
                               overflow: TextOverflow.ellipsis,
-                            ),
+                            )),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('シグニチャー カラー アイズ',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥7,700', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.62', style: TextStyle(fontSize: 9)),
+                              Text('(8726件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('アイ カラー クォード',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥12,980', style: TextStyle(fontSize: 9)),
+                              alignment: Alignment.topLeft,
+                              child: Icon(Icons.trending_up, size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('Dior',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFF777777)),
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('ディオールショウ サンク クルール',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥9,570', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.51', style: TextStyle(fontSize: 9)),
+                              Text('(913件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.65', style: TextStyle(fontSize: 9)),
-                                Text('(8161件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
+                              height: 90),
+                          const Align(
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                          const Align(
+                              alignment: Alignment.topLeft,
+                              child: Icon(Icons.trending_up, size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'TOM FORD BEAUTY(トムフォードビューティ)',
+                            style: TextStyle(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF777777)),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('アイ カラー クォード',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥12,980', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.65', style: TextStyle(fontSize: 9)),
+                              Text('(8161件)', style: TextStyle(fontSize: 9)),
+                            ],
+                          ),
+                        )
+                      ],
                     ),
                   ),
                 ],
@@ -249,203 +240,194 @@ class _RankingScreenState extends State<RankingPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   // アイテムのセル
-                  SizedBox(
+                  Container(
+                    // issue: marginとpaddingの使い分けどうしよう
+                    // ランキング順位はセルの左上端に合わせたいけど画像より下のテキストは周りに余白をつけたい
+                    // padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(8),
                     height: 210,
                     width: 120,
-                    child: Container(
-                      // issue: marginとpaddingの使い分けどうしよう
-                      // ランキング順位はセルの左上端に合わせたいけど画像より下のテキストは周りに余白をつけたい
-                      // padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
-                                height: 90),
-                            Align(
-                              alignment: Alignment.topLeft,
-                              child: Container(
-                                alignment: Alignment.center,
-                                width: 20,
-                                height: 20,
-                                color: Colors.grey,
-                                child: const Text('01',
-                                    style: TextStyle(
-                                        fontSize: 9, color: Colors.white)),
-                              ),
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
+                              height: 90),
+                          Align(
+                            alignment: Alignment.topLeft,
+                            child: Container(
+                              alignment: Alignment.center,
+                              width: 20,
+                              height: 20,
+                              color: Colors.grey,
+                              child: const Text('01',
+                                  style: TextStyle(
+                                      fontSize: 9, color: Colors.white)),
                             ),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                'SUQQU',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis,
-                              )),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('シグニチャー カラー アイズ',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥7,700', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.62', style: TextStyle(fontSize: 9)),
-                                Text('(8726件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('Dior',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis),
                           ),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('ディオールショウ サンク クルール',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥9,570', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.51', style: TextStyle(fontSize: 9)),
-                                Text('(913件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
                             alignment: Alignment.centerLeft,
                             child: Text(
-                              'TOM FORD BEAUTY(トムフォードビューティ)',
+                              'SUQQU',
                               style: TextStyle(
                                   fontSize: 11,
                                   fontWeight: FontWeight.bold,
                                   color: Color(0xFF777777)),
                               overflow: TextOverflow.ellipsis,
-                            ),
+                            )),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('シグニチャー カラー アイズ',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥7,700', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.62', style: TextStyle(fontSize: 9)),
+                              Text('(8726件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('アイ カラー クォード',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('Dior',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFF777777)),
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('ディオールショウ サンク クルール',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥9,570', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.51', style: TextStyle(fontSize: 9)),
+                              Text('(913件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
-                          const SizedBox(height: 3),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥12,980', style: TextStyle(fontSize: 9)),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'TOM FORD BEAUTY(トムフォードビューティ)',
+                            style: TextStyle(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF777777)),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.65', style: TextStyle(fontSize: 9)),
-                                Text('(8161件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('アイ カラー クォード',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥12,980', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.65', style: TextStyle(fontSize: 9)),
+                              Text('(8161件)', style: TextStyle(fontSize: 9)),
+                            ],
+                          ),
+                        )
+                      ],
                     ),
                   ),
                 ],
@@ -454,190 +436,181 @@ class _RankingScreenState extends State<RankingPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   // アイテムのセル
-                  SizedBox(
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
                     height: 210,
                     width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
+                              height: 90),
                           const Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                'SUQQU',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis,
-                              )),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('シグニチャー カラー アイズ',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥7,700', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.62', style: TextStyle(fontSize: 9)),
-                                Text('(8726件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('Dior',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis),
-                          ),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            // issue: テキストを2行で表示しない場合も2行分のスペースを空けたい
-                            child: Text('ディオール',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥9,570', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.51', style: TextStyle(fontSize: 9)),
-                                Text('(913件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
                             alignment: Alignment.centerLeft,
                             child: Text(
-                              'TOM FORD BEAUTY(トムフォードビューティ)',
+                              'SUQQU',
                               style: TextStyle(
                                   fontSize: 11,
                                   fontWeight: FontWeight.bold,
                                   color: Color(0xFF777777)),
                               overflow: TextOverflow.ellipsis,
-                            ),
+                            )),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('シグニチャー カラー アイズ',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥7,700', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.62', style: TextStyle(fontSize: 9)),
+                              Text('(8726件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('アイ カラー クォード',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('Dior',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFF777777)),
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          // issue: テキストを2行で表示しない場合も2行分のスペースを空けたい
+                          child: Text('ディオール',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥9,570', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.51', style: TextStyle(fontSize: 9)),
+                              Text('(913件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
-                          const SizedBox(height: 3),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥12,980', style: TextStyle(fontSize: 9)),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'TOM FORD BEAUTY(トムフォードビューティ)',
+                            style: TextStyle(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF777777)),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.65', style: TextStyle(fontSize: 9)),
-                                Text('(8161件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('アイ カラー クォード',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥12,980', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.65', style: TextStyle(fontSize: 9)),
+                              Text('(8161件)', style: TextStyle(fontSize: 9)),
+                            ],
+                          ),
+                        )
+                      ],
                     ),
                   ),
                 ],
@@ -646,190 +619,181 @@ class _RankingScreenState extends State<RankingPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   // アイテムのセル
-                  SizedBox(
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
                     height: 210,
                     width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/2a887d54a85339d23b882e29-1610080449.png',
+                              height: 90),
                           const Align(
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                'SUQQU',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis,
-                              )),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('シグニチャー カラー アイズ',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥7,700', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.62', style: TextStyle(fontSize: 9)),
-                                Text('(8726件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('Dior',
-                                style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: Color(0xFF777777)),
-                                overflow: TextOverflow.ellipsis),
-                          ),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            // issue: テキストを2行で表示しない場合も2行分のスペースを空けたい
-                            child: Text('ディオール',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
-                          ),
-                          const SizedBox(height: 3),
-                          const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥9,570', style: TextStyle(fontSize: 9)),
-                          ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.51', style: TextStyle(fontSize: 9)),
-                                Text('(913件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
-                    ),
-                  ),
-                  // アイテムのセル
-                  SizedBox(
-                    height: 210,
-                    width: 120,
-                    child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: Colors.white),
-                      child: Column(
-                        children: [
-                          Stack(children: [
-                            Image.network(
-                                'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
-                                height: 90),
-                            const Align(
-                                alignment: Alignment.bottomRight,
-                                child: Icon(Icons.bookmark_border_outlined,
-                                    size: 24)),
-                          ]),
-                          const Align(
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
                             alignment: Alignment.centerLeft,
                             child: Text(
-                              'TOM FORD BEAUTY(トムフォードビューティ)',
+                              'SUQQU',
                               style: TextStyle(
                                   fontSize: 11,
                                   fontWeight: FontWeight.bold,
                                   color: Color(0xFF777777)),
                               overflow: TextOverflow.ellipsis,
-                            ),
+                            )),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('シグニチャー カラー アイズ',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥7,700', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.62', style: TextStyle(fontSize: 9)),
+                              Text('(8726件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/65b413ae555ebd623ae02de1-1699509212.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text('アイ カラー クォード',
-                                style: TextStyle(fontSize: 11),
-                                overflow: TextOverflow.ellipsis,
-                                maxLines: 2),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('Dior',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFF777777)),
+                              overflow: TextOverflow.ellipsis),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          // issue: テキストを2行で表示しない場合も2行分のスペースを空けたい
+                          child: Text('ディオール',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥9,570', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.51', style: TextStyle(fontSize: 9)),
+                              Text('(913件)', style: TextStyle(fontSize: 9)),
+                            ],
                           ),
-                          const SizedBox(height: 3),
+                        )
+                      ],
+                    ),
+                  ),
+                  // アイテムのセル
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    margin: const EdgeInsets.all(4),
+                    height: 210,
+                    width: 120,
+                    decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.white),
+                    child: Column(
+                      children: [
+                        Stack(children: [
+                          Image.network(
+                              'https://cloudflare.lipscosme.com/image/98a32d6a0f69e9873608d1de-1638145601.png',
+                              height: 90),
                           const Align(
-                            alignment: Alignment.centerLeft,
-                            child:
-                                Text('¥12,980', style: TextStyle(fontSize: 9)),
+                              alignment: Alignment.bottomRight,
+                              child: Icon(Icons.bookmark_border_outlined,
+                                  size: 24)),
+                        ]),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'TOM FORD BEAUTY(トムフォードビューティ)',
+                            style: TextStyle(
+                                fontSize: 11,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF777777)),
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          const SizedBox(height: 3),
-                          Container(
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: const Color(0xFFF7F7F7)),
-                            child: const Row(
-                              children: [
-                                Icon(Icons.star, size: 9),
-                                Text('4.65', style: TextStyle(fontSize: 9)),
-                                Text('(8161件)', style: TextStyle(fontSize: 9)),
-                              ],
-                            ),
-                          )
-                        ],
-                      ),
+                        ),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('アイ カラー クォード',
+                              style: TextStyle(fontSize: 11),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2),
+                        ),
+                        const SizedBox(height: 3),
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text('¥12,980', style: TextStyle(fontSize: 9)),
+                        ),
+                        const SizedBox(height: 3),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: const Color(0xFFF7F7F7)),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.star, size: 9),
+                              Text('4.65', style: TextStyle(fontSize: 9)),
+                              Text('(8161件)', style: TextStyle(fontSize: 9)),
+                            ],
+                          ),
+                        )
+                      ],
                     ),
                   ),
                 ],


### PR DESCRIPTION
## 対応issue
#3 
## 実施内容
`sizedBox`と`container`の役割を確認した上でアイテムのwidgetを囲む`sizedBox`を削除し`container`で囲むように変更しました。